### PR TITLE
doc: update bbin install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ bbin 0.1.12
 
 
 ``` bash
-$ bbin install https://github.com/eval/deps-try/releases/download/stable/deps-try.jar
+$ bbin install https://github.com/eval/deps-try/releases/download/stable/deps-try-bb.jar
 
 # Check version
-$ deps-try -v
+$ deps-try-bb -v
 
 # Re-run the install command to upgrade
 ```


### PR DESCRIPTION
I tried following the installation instructions for deps-try using bbin, and they no longer work. The install path seems to have changed, with the jar now being called deps-try-bb.jar instead of deps-try.jar.